### PR TITLE
Fix baselineRatio calculation when break-word word-wrap

### DIFF
--- a/js/baseline-ratio.js
+++ b/js/baseline-ratio.js
@@ -31,6 +31,7 @@
     container.style.padding = "0";
     container.style.visibility = "hidden";
     container.style.overflow = "hidden";
+    container.style.wordWrap = "normal";
 
     // Intentionally unprotected style definition.
     var small = document.createElement('span');


### PR DESCRIPTION
When the inherited CSS (from `elem` or otherwise) has `word-wrap: break-word`, `baselineRatio` ends up being calculated incorrectly as the small and large “X” end up on different lines. This was recently reported to SmartUnderline where I implemented [EagerIO/SmartUnderline#10](https://github.com/EagerIO/SmartUnderline/issues/10), so I thought I’d contribute back. :smile: 
